### PR TITLE
#5 add tips button containing all tooltips

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -59,82 +59,80 @@
             cols="12"
             sm="12"
           >
-
-                <v-select
-                  v-model="tree_selected"
-                  :items="tree_list"
-                  label="Pick a tree"
-                  @change="tree_change(); submit();"
-                  return-object
-                ></v-select>
-
+          <v-select
+            v-model="tree_selected"
+            :items="tree_list"
+            label="Pick a tree"
+            @change="tree_change(); submit();"
+            return-object
+          ></v-select>
           </v-col>
           <v-col cols="12">
             <header>
               Iterations
             </header>
-            <v-tooltip left>
-              <template v-slot:activator="{ on }">
-                <v-slider
-                  v-on="on"
-                  v-model="settings.iterations"
-                  :max="10"
-                  :min="0"
-                  class="align-left"
-                  :thumb-size="12"
-                  thumb-label
-                  step="1"
-                  ticks
-                >
-                </v-slider>
-              </template>
-            <span>How many times should the <br>production rules be applied?</span>
-          </v-tooltip>
+            <v-slider
+              v-model="settings.iterations"
+              :max="10"
+              :min="0"
+              class="align-left"
+              :thumb-size="12"
+              thumb-label
+              step="1"
+              ticks
+              >
+            </v-slider>
           </v-col>
 
           <v-col cols="12">
             <header>
               Rotation (˚)
             </header>
-            <v-tooltip left>
-              <template v-slot:activator="{ on }">
-                <v-slider
-                  v-on="on"
-                  v-model="settings.angle"
-                  :max="180"
-                  :min="0"
-                  class="align-left"
-                  :thumb-size="12"
-                  thumb-label
-                  step="0.5"
-                  ticks
-                >
-                </v-slider>
-              </template>
-            <span>At what angle should <br>branches diverge?</span>
-          </v-tooltip>
+            <v-slider
+              v-model="settings.angle"
+              :max="180"
+              :min="0"
+              class="align-left"
+              :thumb-size="12"
+              thumb-label
+              step="0.5"
+              ticks
+            >
+            </v-slider>
           </v-col>
 
           <v-col cols="12">
             <header>
               Line Length
             </header>
-            <v-tooltip left>
-              <template v-slot:activator="{ on }">
-                <v-slider
-                  v-on="on"
-                  v-model="settings.line_length"
-                  :max="10"
-                  :min="0"
-                  class="align-left"
-                  :thumb-size="12"
-                  thumb-label
-                  step="1"
-                  ticks
-                >
-                </v-slider>
-              </template>
-            <span>How long should the <br>branches be?</span>
+            <v-slider
+              v-model="settings.line_length"
+              :max="10"
+              :min="0"
+              class="align-left"
+              :thumb-size="12"
+              thumb-label
+              step="1"
+              ticks
+            >
+            </v-slider>
+          <v-tooltip bottom>      
+            <template v-slot:activator="{ on, attrs }">        
+              <v-btn          
+                color="red lighten-2"          
+                dark          
+                v-bind="attrs"          
+                v-on="on"        
+                >          
+                Tips        
+                </v-btn>      
+               </template>      
+            <span>
+              Pick a tree: Which default tree do you want to start with?<br>
+              Iterations: How many times will productions be applied?<br>
+              Rotation: At what angle should the branches diverge?<br>
+              Line Length: How long should the branches be?
+            </span>    
           </v-tooltip>
           </v-col>
         </v-row>
@@ -195,7 +193,7 @@
             Details
           </v-btn>
         </template>
-        <span>Get more info on <br>this type of tree!</span>
+        <span>More about this<br>type of tree!</span>
       </v-tooltip>
     </v-card-actions>
 


### PR DESCRIPTION
I removed the tooltips on the individual sliders and the tree dropdown menu, now we have a button called tips at the bottom which shows all tooltips on hover.